### PR TITLE
Add Jujutsu config

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -17,6 +17,7 @@
     ./gitui.nix
     ./intellij
     ./java.nix
+    ./jujutsu.nix
     ./neovim.nix
     ./overlays.nix
     ./starship.nix

--- a/git.nix
+++ b/git.nix
@@ -1,14 +1,17 @@
 {
   programs.git = {
     enable = true;
-    userName = "Tomasz Mikus";
-    userEmail = "mikus.tomasz@gmail.com";
-    aliases = {
-      ci = "commit";
-      co = "checkout";
-      s = "status";
-    };
-    extraConfig = {
+    settings = {
+      user = {
+        name = "Tomasz Mikus";
+        email = "tomasz@mikus.uk";
+      };
+      alias = {
+        ci = "commit";
+        co = "checkout";
+        s = "status";
+      };
+      # extraConfig = {
       # Delta config
       core = {
         pager = "delta";

--- a/jujutsu.nix
+++ b/jujutsu.nix
@@ -1,0 +1,11 @@
+{
+  programs.jujutsu = {
+    enable = true;
+    settings = {
+      user = {
+        name = "Tomasz Mikus";
+        email = "tomasz@mikus.uk";
+      };
+    };
+  };
+}


### PR DESCRIPTION
### TL;DR

Added Jujutsu version control system and updated Git configuration

### What changed?

- Added a new `jujutsu.nix` file to configure the Jujutsu version control system
- Updated the Git configuration to use the newer `settings` structure instead of direct properties
- Changed the email address from `mikus.tomasz@gmail.com` to `tomasz@mikus.uk` in Git config
- Added Jujutsu to the imports in `configuration.nix`

### How to test?

1. Run `nixos-rebuild switch` to apply the changes
2. Verify Git works with the new email address by running `git config user.email`
3. Test Jujutsu by running `jj` and checking that it's properly configured

### Why make this change?

- Modernizes the Git configuration to use the newer `settings` structure
- Adds support for Jujutsu, a new VCS that offers improved features over Git
- Updates the email address to use a more professional domain